### PR TITLE
Correct the format of the git tag specified in the podspec file.

### DIFF
--- a/FuzzySearch.podspec
+++ b/FuzzySearch.podspec
@@ -5,7 +5,7 @@ Pod::Spec.new do |spec|
   spec.homepage     = 'https://github.com/rahulnadella/FuzzySearch'
   spec.authors      = { 'Rahul Nadella' => 'rahulnadella@yahoo.com' }
   spec.summary      = 'Utility class to find an approximate match for specific String'
-  spec.source       = { :git => 'https://github.com/rahulnadella/FuzzySearch.git', :tag => 'v1.1.0' }
+  spec.source       = { :git => 'https://github.com/rahulnadella/FuzzySearch.git', :tag => '1.1.0' }
   spec.platform = :ios, '8.0'
   spec.requires_arc = true
   spec.source_files = 'FuzzySearch.swift'


### PR DESCRIPTION
In the repo, version 1.1.0 is tagged as "1.1.0". In the podspec file, the tag is specified as "v1.1.0". This causes a failure when running `pod install`. The tag in the podspec file is changed to "1.1.0".
